### PR TITLE
Fix iot getdeviceid with unexpected LANG setting

### DIFF
--- a/samples/c/iotGetDeviceID.sh
+++ b/samples/c/iotGetDeviceID.sh
@@ -4,7 +4,8 @@ if [ -e "$FILE" ]
 then
 	echo Running in registered mode
 	cat $FILE
-else 
+else
+	LANG=C
 	devId=`/sbin/ifconfig | grep 'eth0' | tr -s ' ' | cut -d ' ' -f5 |  tr -d ':'`
 	echo The device ID is $devId
 	echo For Real-time visualization of the data, visit http://quickstart.internetofthings.ibmcloud.com/?deviceId=$devId


### PR DESCRIPTION
I was running iot getdevice id on my Raspberry which was configured with
LANG=de_DE.UTF-8. In this case getdevice id returned:

pi@raspberrypi:~/Bluemix $ sudo service iot getdeviceid
The device ID is Adresse
...

Which is certainly not the MAC address or anything unique. I propose
to set LANG=C before ifconfig magic is used to get reproducable
results on Rasperries with different nationalities.