### PR TITLE
Fix warnings and one buffer problem, fix iot getdeviceid with unexpected LANG setting

### DIFF
--- a/samples/c/MQTTAsync.h
+++ b/samples/c/MQTTAsync.h
@@ -656,7 +656,7 @@ typedef struct
 } MQTTAsync_connectOptions;
 
 
-#define MQTTAsync_connectOptions_initializer { {'M', 'Q', 'T', 'C'}, 2, 60, 1, 10, NULL, NULL, NULL, 30, 20, NULL, NULL, 0, NULL}
+#define MQTTAsync_connectOptions_initializer { {'M', 'Q', 'T', 'C'}, 2, 60, 1, 10, NULL, NULL, NULL, 30, 20, NULL, NULL, NULL, NULL, 0, NULL}
 
 /**
   * This function attempts to connect a previously-created client (see

--- a/samples/c/Makefile
+++ b/samples/c/Makefile
@@ -5,13 +5,15 @@ CFGDIR=$(DESTDIR)/etc/iotsample-raspberrypi
 COMPILELIBDIR=./lib
 LIBNAME=paho-mqtt3as
 
+CFLAGS ?= -Wall -W -O2
+
 all: iot
 
 .PHONY: all install clean distclean
 
 iot: iotmain.c cpustat.c mac.c mqttPublisher.c jsonator.c iot.h jsonReader.c
 	export LIBRARY_PATH=$(COMPILELIBDIR):$(LIBRARY_PATH)
-	$(CC) iotmain.c cpustat.c mac.c mqttPublisher.c jsonator.c cJSON.c jsonReader.c -o $@ -l$(LIBNAME) -lpthread -lssl -lm -L $(COMPILELIBDIR) -I .
+	$(CC) $(CFLAGS) iotmain.c cpustat.c mac.c mqttPublisher.c jsonator.c cJSON.c jsonReader.c -o $@ -l$(LIBNAME) -lpthread -lssl -lm -L $(COMPILELIBDIR) -I .
 	strip $@
 
 install: iot

--- a/samples/c/iotGetDeviceID.sh
+++ b/samples/c/iotGetDeviceID.sh
@@ -4,7 +4,8 @@ if [ -e "$FILE" ]
 then
 	echo Running in registered mode
 	cat $FILE
-else 
+else
+	LANG=C
 	devId=`/sbin/ifconfig | grep 'eth0' | tr -s ' ' | cut -d ' ' -f5 |  tr -d ':'`
 	echo The device ID is $devId
 	echo For Real-time visualization of the data, visit http://quickstart.internetofthings.ibmcloud.com/?deviceId=$devId

--- a/samples/c/iotmain.c
+++ b/samples/c/iotmain.c
@@ -14,6 +14,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <ctype.h>
 #include <math.h>
 #include <signal.h>
 #include "iot.h"
@@ -68,11 +69,12 @@ int disconnect_mqtt_client(MQTTAsync* client);
 int reconnect(MQTTAsync* client, int isRegistered,
 		char* username, char* passwd);
 
-int main(int argc, char **argv) {
+int main(int argc __attribute__((unused)),
+	 char **argv __attribute__((unused))) {
 
 	char* json;
 
-	int lckStatus;
+	/* int lckStatus; */
 	int res;
 	int sleepTimeout;
 	struct config configstr;
@@ -215,7 +217,7 @@ float sineVal(float minValue, float maxValue, float duration, float count) {
 }
 
 // Signal handler to handle when the user tries to kill this process. Try to close down gracefully
-void sig_handler(int signo) {
+void sig_handler(int signo __attribute__((unused))) {
 	syslog(LOG_INFO, "Received the signal to terminate the IoT process. \n");
 	syslog(LOG_INFO,
 			"Trying to end the process gracefully. Closing the MQTT connection. \n");
@@ -279,7 +281,7 @@ char *trim(char *str) {
 int get_config(char * filename, struct config * configstr) {
 
 	FILE* prop;
-	char str1[10], str2[10];
+	/* char str1[10], str2[10]; */
 	prop = fopen(filename, "r");
 	if (prop == NULL) {
 		syslog(LOG_INFO,"Config file not found. Going to Quickstart mode\n");

--- a/samples/c/mqttPublisher.c
+++ b/samples/c/mqttPublisher.c
@@ -46,7 +46,8 @@ int getDelay(char *text);
 /*
  * This function is called when the message is successfully published
  */
-void onSend(void* context, MQTTAsync_successData* response) {
+void onSend(void* context __attribute__((unused)),
+	MQTTAsync_successData* response) {
 
 #ifdef FINE
 	syslog(LOG_DEBUG, "Event with token value %d delivery confirmed\n",
@@ -57,7 +58,8 @@ void onSend(void* context, MQTTAsync_successData* response) {
 /*
  * This function is called when the subscription succeeds
  */
-void onSubscription(void* context, MQTTAsync_successData* response) {
+void onSubscription(void* context __attribute__((unused)),
+	MQTTAsync_successData* response __attribute__((unused))) {
 
 #ifdef FINE
 	syslog(LOG_INFO, "Subscription succeeded\n");
@@ -67,7 +69,8 @@ void onSubscription(void* context, MQTTAsync_successData* response) {
 /*
  * Called when the connection is successful. Update the connected variable
  */
-void onConnectSuccess(void* context, MQTTAsync_successData* response) {
+void onConnectSuccess(void* context __attribute__((unused)),
+	MQTTAsync_successData* response __attribute__((unused))) {
 
 #ifdef FINE
 	syslog(LOG_INFO, "Connection was successful\n");
@@ -98,7 +101,8 @@ int disconnect_mqtt_client(MQTTAsync* client) {
 /* 
  * On failure of connection to server, print the response code 
  */
-void onConnectFailure(void* context, MQTTAsync_failureData* response) {
+void onConnectFailure(void* context __attribute__((unused)),
+	MQTTAsync_failureData* response) {
 #ifdef ERROR
 	syslog(LOG_ERR, "Connect failed ");
 	if (response) {
@@ -112,11 +116,12 @@ void onConnectFailure(void* context, MQTTAsync_failureData* response) {
 /*
  * Function to process the subscribed messages
  */
-int subscribeMessage(void *context, char *topicName, int topicLen,
+int subscribeMessage(void *context __attribute__((unused)),
+		char *topicName, int topicLen __attribute__((unused)),
 		MQTTAsync_message *message) {
-	int i;
+	/* int i; */
 	char* payloadptr;
-	char* command;
+	char command[100];
 	int time_delay = 0;
 
 	payloadptr = message->payload;


### PR DESCRIPTION
I think at least the buffer problem you should really take. Please have a look.

    +int subscribeMessage(void *context __attribute__((unused)),
    +		char *topicName, int topicLen __attribute__((unused)),
     		MQTTAsync_message *message) {
    -	int i;
    +	/* int i; */
     	char* payloadptr;
    -	char* command;
    +	char command[100];
     	int time_delay = 0;
      
     	payloadptr = message->payload;

and you use sprintf with command later on.