### PR TITLE
Get network interface id from device.cfg. Closes #3

### DIFF
--- a/samples/c/README.md
+++ b/samples/c/README.md
@@ -83,7 +83,7 @@ Onboard your device onto the Internet of Things Cloud. You will get the followin
 3. Device ID
 4. Authetication Method
 5. Authetication Token
-
+6. Network Interface ID
 
 Stop the iot process
 		
@@ -99,6 +99,7 @@ type = iotsample-raspberrypi
 id =b827eba84426
 auth-method=token
 auth-token = yourAuthToken
+network-id = eth0
 #End of Configuration file.	
 
 Note: All the properties in the configuration file are mandatory.

--- a/samples/c/iotmain.c
+++ b/samples/c/iotmain.c
@@ -44,6 +44,7 @@ struct config {
 	char id[MAXBUF];
 	char authmethod[MAXBUF];
 	char authtoken[MAXBUF];
+	char nic[MAXBUF];
 };
 
 int get_config(char* filename, struct config * configstr);
@@ -115,7 +116,7 @@ int main(int argc __attribute__((unused)),
 	}
 
 	// read the events
-	char* mac_address = getmac("eth0");
+	char* mac_address = getmac(configstr.nic);
 	getClientId(&configstr, mac_address);
 	//the timeout between the connection retry
 	int connDelayTimeout = 1;	// default sleep for 1 sec
@@ -311,6 +312,8 @@ int get_config(char * filename, struct config * configstr) {
 			strncpy(configstr->authtoken, value, MAXBUF);
 		else if (strcmp(prop, "auth-method") == 0)
 					strncpy(configstr->authmethod, value, MAXBUF);
+		else if (strcmp(prop, "network-id") == 0)
+					strncpy(configstr->nic, value, MAXBUF);
 	}
 
 	return 1;


### PR DESCRIPTION
Device.cfg will have an additional argument "network-id". Frees the code from hard coded eth0.

Note : Does not impact iotGetDeviceID.sh (quickstart scenario)